### PR TITLE
Remove redundant PostCSS config

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,0 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
-};
-
-export default config;


### PR DESCRIPTION
## Summary
- keep `postcss.config.js` as the single PostCSS config
- delete `postcss.config.mjs`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684caf6e02f48323987405b829db6942