### PR TITLE
Fix duplicate import in globals.css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,8 +5,6 @@
 @tailwind components;
 @tailwind utilities;
 /* Si sigues usando animaciones de tw-animate-css: */
-@import "tw-animate-css";
-
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## Summary
- remove redundant `@import "tw-animate-css";` statement from `src/app/globals.css`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cafa510788323933ac060d260e550